### PR TITLE
Add PENDING_CANCELLATION state #260

### DIFF
--- a/src/components/auction/OrdersTable/index.tsx
+++ b/src/components/auction/OrdersTable/index.tsx
@@ -147,7 +147,7 @@ const OrderTable: React.FC<OrderTableProps> = (props) => {
   const orderStatusText = {
     [OrderStatus.PLACED]: 'Placed',
     [OrderStatus.PENDING]: 'Pending',
-    [OrderStatus.PENDING_CANCELLATION]: 'Pending-Cancellation',
+    [OrderStatus.PENDING_CANCELLATION]: 'Cancelling',
   }
   const now = Math.trunc(Date.now())
   const ordersEmpty = !orders.orders || orders.orders.length == 0

--- a/src/components/auction/OrdersTable/index.tsx
+++ b/src/components/auction/OrdersTable/index.tsx
@@ -147,7 +147,7 @@ const OrderTable: React.FC<OrderTableProps> = (props) => {
   const orderStatusText = {
     [OrderStatus.PLACED]: 'Placed',
     [OrderStatus.PENDING]: 'Pending',
-    [OrderStatus.PENDING_CANCELLATION]: 'Pending-Cancelation',
+    [OrderStatus.PENDING_CANCELLATION]: 'Pending-Cancellation',
   }
   const now = Math.trunc(Date.now())
   const ordersEmpty = !orders.orders || orders.orders.length == 0
@@ -235,17 +235,10 @@ const OrderTable: React.FC<OrderTableProps> = (props) => {
                   align="flex-start"
                   itemKey={<span>Status</span>}
                   itemValue={
-                    order.status === OrderStatus.PLACED ? (
-                      <>
-                        <span>{orderStatusText[order.status]}</span>
-                        <OrderPlaced />
-                      </>
-                    ) : (
-                      <>
-                        <span>{orderStatusText[order.status]}</span>
-                        <OrderPending />
-                      </>
-                    )
+                    <>
+                      <span>{orderStatusText[order.status]}</span>
+                      {order.status === OrderStatus.PLACED ? <OrderPlaced /> : <OrderPending />}
+                    </>
                   }
                 />
               </Cell>

--- a/src/components/auction/OrdersTable/index.tsx
+++ b/src/components/auction/OrdersTable/index.tsx
@@ -101,7 +101,6 @@ const OrderTable: React.FC<OrderTableProps> = (props) => {
     auctionIdentifier,
     derivedAuctionInfo?.biddingToken,
   )
-  const { onDeleteOrder } = useOrderActionHandlers()
   const [showConfirm, setShowConfirm] = useState<boolean>(false)
   const [showWarning, setShowWarning] = useState<boolean>(false)
   const [attemptingTxn, setAttemptingTxn] = useState<boolean>(false) // clicked confirmed
@@ -121,7 +120,6 @@ const OrderTable: React.FC<OrderTableProps> = (props) => {
 
     cancelOrderCallback(orderId)
       .then((hash) => {
-        onDeleteOrder(orderId)
         setTxHash(hash)
         setPendingConfirmation(false)
       })
@@ -131,14 +129,7 @@ const OrderTable: React.FC<OrderTableProps> = (props) => {
         setPendingConfirmation(false)
         setShowWarning(true)
       })
-  }, [
-    setAttemptingTxn,
-    setTxHash,
-    setPendingConfirmation,
-    onDeleteOrder,
-    orderId,
-    cancelOrderCallback,
-  ])
+  }, [setAttemptingTxn, setTxHash, setPendingConfirmation, orderId, cancelOrderCallback])
 
   const hasLastCancellationDate =
     derivedAuctionInfo?.auctionEndDate !== derivedAuctionInfo?.orderCancellationEndDate &&
@@ -195,7 +186,7 @@ const OrderTable: React.FC<OrderTableProps> = (props) => {
       {!ordersEmpty && (
         <TableWrapper>
           {ordersSortered.map((order, index) => (
-            <Row columns={hideCancelButton ? 4 : 5} key={index}>
+            <Row columns={hideCancelButton ? 4 : 5} key={order.id}>
               <Cell>
                 <KeyValue
                   align="flex-start"
@@ -268,7 +259,10 @@ const OrderTable: React.FC<OrderTableProps> = (props) => {
                 <ButtonCell>
                   <ButtonWrapper>
                     <ActionButton
-                      disabled={isOrderCancellationExpired}
+                      disabled={
+                        isOrderCancellationExpired ||
+                        order.status === OrderStatus.PENDING_CANCELLATION
+                      }
                       onClick={() => {
                         setOrderId(order.id)
                         setShowConfirm(true)

--- a/src/components/auction/OrdersTable/index.tsx
+++ b/src/components/auction/OrdersTable/index.tsx
@@ -10,7 +10,7 @@ import {
   useSwapState,
 } from '../../../state/orderPlacement/hooks'
 import { AuctionIdentifier } from '../../../state/orderPlacement/reducer'
-import { useOrderActionHandlers, useOrderState } from '../../../state/orders/hooks'
+import { useOrderState } from '../../../state/orders/hooks'
 import { OrderState, OrderStatus } from '../../../state/orders/reducer'
 import { abbreviation } from '../../../utils/numeral'
 import { getInverse } from '../../../utils/prices'
@@ -144,6 +144,11 @@ const OrderTable: React.FC<OrderTableProps> = (props) => {
   )
 
   const pendingText = `Cancelling Order`
+  const orderStatusText = {
+    [OrderStatus.PLACED]: 'Placed',
+    [OrderStatus.PENDING]: 'Pending',
+    [OrderStatus.PENDING_CANCELLATION]: 'Pending-Cancelation',
+  }
   const now = Math.trunc(Date.now())
   const ordersEmpty = !orders.orders || orders.orders.length == 0
 
@@ -232,12 +237,12 @@ const OrderTable: React.FC<OrderTableProps> = (props) => {
                   itemValue={
                     order.status === OrderStatus.PLACED ? (
                       <>
-                        <span>Placed</span>
+                        <span>{orderStatusText[order.status]}</span>
                         <OrderPlaced />
                       </>
                     ) : (
                       <>
-                        <span>Pending</span>
+                        <span>{orderStatusText[order.status]}</span>
                         <OrderPending />
                       </>
                     )

--- a/src/hooks/useCancelOrderCallback.ts
+++ b/src/hooks/useCancelOrderCallback.ts
@@ -6,6 +6,7 @@ import { Contract } from '@ethersproject/contracts'
 
 import { chainNames } from '../constants'
 import { AuctionIdentifier } from '../state/orderPlacement/reducer'
+import { useOrderActionHandlers } from '../state/orders/hooks'
 import { useTransactionAdder } from '../state/transactions/hooks'
 import { ChainId, calculateGasMargin, getEasyAuctionContract } from '../utils'
 import { getLogger } from '../utils/logger'
@@ -22,6 +23,7 @@ export function useCancelOrderCallback(
 ): null | ((orderId: string) => Promise<string>) {
   const { account, chainId, library } = useActiveWeb3React()
   const addTransaction = useTransactionAdder()
+  const { onCancelOrder: actionCancelOrder } = useOrderActionHandlers()
   const { auctionId, chainId: orderChainId } = auctionIdentifier
   const gasPrice = useGasPrice(chainId)
 
@@ -74,6 +76,8 @@ export function useCancelOrderCallback(
               ' ' +
               biddingToken.symbol,
           })
+          actionCancelOrder(orderId)
+
           return response.hash
         })
         .catch((error) => {
@@ -81,5 +85,16 @@ export function useCancelOrderCallback(
           throw error
         })
     }
-  }, [account, orderChainId, gasPrice, addTransaction, chainId, library, auctionId, biddingToken])
+  }, [
+    chainId,
+    library,
+    account,
+    orderChainId,
+    auctionId,
+    gasPrice,
+    addTransaction,
+    biddingToken.decimals,
+    biddingToken.symbol,
+    actionCancelOrder,
+  ])
 }

--- a/src/state/orders/actions.ts
+++ b/src/state/orders/actions.ts
@@ -10,10 +10,15 @@ export const resetOrders = createAction<{
   orders: OrderDisplay[]
 }>('ResetOrders')
 
+export const cancelOrders = createAction<{
+  orderId: string
+}>('CancelOrders')
+
 export const removeOrders = createAction<{
   orderId: string
 }>('RemoveOrders')
 
 export const finalizeOrderPlacement = createAction<void>('finalizeOrderPlacement')
+export const finalizeOrderCancellation = createAction<void>('finalizeOrderCancellation')
 
 export const loadOrderFromAPI = createAction<void>('LoadOrderFromAPI')

--- a/src/state/orders/hooks.ts
+++ b/src/state/orders/hooks.ts
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { AppDispatch, AppState } from '..'
 import {
   appendOrders,
+  cancelOrders,
   finalizeOrderPlacement,
   loadOrderFromAPI,
   removeOrders,
@@ -19,6 +20,7 @@ export function useOrderState(): AppState['orders'] {
 export function useOrderActionHandlers(): {
   onResetOrder: (orders: OrderDisplay[]) => void
   onNewOrder: (orders: OrderDisplay[]) => void
+  onCancelOrder: (orderId: string) => void
   onDeleteOrder: (orderId: string) => void
   onFinalizeOrder: () => void
   onReloadFromAPI: () => void
@@ -45,6 +47,12 @@ export function useOrderActionHandlers(): {
     dispatch(loadOrderFromAPI())
   }, [dispatch])
 
+  const onCancelOrder = useCallback(
+    (orderId: string) => {
+      dispatch(cancelOrders({ orderId }))
+    },
+    [dispatch],
+  )
   const onDeleteOrder = useCallback(
     (orderId: string) => {
       dispatch(removeOrders({ orderId }))
@@ -52,5 +60,12 @@ export function useOrderActionHandlers(): {
     [dispatch],
   )
 
-  return { onResetOrder, onNewOrder, onReloadFromAPI, onFinalizeOrder, onDeleteOrder }
+  return {
+    onResetOrder,
+    onNewOrder,
+    onReloadFromAPI,
+    onFinalizeOrder,
+    onCancelOrder,
+    onDeleteOrder,
+  }
 }

--- a/src/state/transactions/updater.tsx
+++ b/src/state/transactions/updater.tsx
@@ -6,7 +6,7 @@ import { useActiveWeb3React } from '../../hooks'
 import { getLogger } from '../../utils/logger'
 import { useAddPopup, useBlockNumber } from '../application/hooks'
 import { AppDispatch, AppState } from '../index'
-import { finalizeOrderPlacement } from '../orders/actions'
+import { finalizeOrderCancellation, finalizeOrderPlacement } from '../orders/actions'
 import { finalizeTransaction } from './actions'
 
 const logger = getLogger('transactions/updater')
@@ -51,6 +51,7 @@ export default function Updater() {
                   },
                 }),
               )
+              dispatch(finalizeOrderCancellation())
               dispatch(finalizeOrderPlacement())
               // add success or failure popup
               if (receipt.status === 1) {


### PR DESCRIPTION
Added a status of `PENDING_CANCELLATION`

When an order is cancelled, disappeared immediately using the action [`RemoveOrders`](https://github.com/gnosis/ido-ux/blob/fec72ef5156b4dafb6ecfc5c70945ab4a6a19629/src/state/orders/actions.ts#L13) .

Adding a new status [can be set individually](https://github.com/henrypalacios/ido-ux/blob/ad51de32c7cf51c11b041425360909cd9528200e/src/state/orders/reducer.ts#L51), and after confirmation [it will be removed](https://github.com/henrypalacios/ido-ux/blob/ad51de32c7cf51c11b041425360909cd9528200e/src/state/transactions/updater.tsx#L54).

I have also disabled the cancel button once it has been pressed.
![Selection_264](https://user-images.githubusercontent.com/4270166/116887328-9255b500-ac00-11eb-8cf8-449a5dc2e137.png)

Issue: [260](https://github.com/gnosis/ido-ux/issues/260)
_auctionId_: 17
_chainId_: 4
